### PR TITLE
Basic passive healthchecks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,12 +9,13 @@ Some ideas that might be fun to incorporate
 
 - [x] multiple targets
     - Decide on upstream target based on hostname, uri, port, etc
-- [x] Multiple listeners - port 80, 443, and whatever else we want to configure
+- [x] Multiple listeners - port 80, 443, and whatever else we want to configur
 - [x] graceful shutdown
 - [ ] Dynamic configuration
     - graceful reloading
 - [x] Multiple backends (AKA load balancing)
-- [ ] Health checks
+- [x] Passive Health checks
+- [ ] Active Health Checks
 - [ ] Dynamic behavior on incoming requests (e.g. send job to SQS)
 - [ ] Dynamic behavior on returned requests (e.g. read a response header and replay request somewhere else)
 - [ ] h2c (backend, or backend AND frontend)?

--- a/reverseproxy/context.go
+++ b/reverseproxy/context.go
@@ -1,0 +1,41 @@
+package reverseproxy
+
+import "context"
+
+var VarsCtxKey = "data-key"
+
+func InitRequestContext() context.Context {
+	var data = map[string]any{"init": true}
+	return context.WithValue(context.Background(), VarsCtxKey, data)
+}
+
+// GetVar gets a value out of the context's variable table by key.
+// If the key does not exist, the return value will be nil.
+func GetVar(ctx context.Context, key string) any {
+	varMap, ok := ctx.Value(VarsCtxKey).(map[string]any)
+	if !ok {
+		return nil
+	}
+	return varMap[key]
+}
+
+// SetVar sets a value in the context's variable table with
+// the given key. It overwrites any previous value with the
+// same key.
+//
+// If the value is nil (note: non-nil interface with nil
+// underlying value does not count) and the key exists in
+// the table, the key+value will be deleted from the table.
+func SetVar(ctx context.Context, key string, value any) {
+	varMap, ok := ctx.Value(VarsCtxKey).(map[string]any)
+	if !ok {
+		return
+	}
+	if value == nil {
+		if _, ok := varMap[key]; ok {
+			delete(varMap, key)
+			return
+		}
+	}
+	varMap[key] = value
+}

--- a/reverseproxy/target.go
+++ b/reverseproxy/target.go
@@ -1,24 +1,57 @@
 package reverseproxy
 
 import (
+	"errors"
 	"github.com/gorilla/mux"
 	"net/url"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 type Target struct {
 	router       *mux.Router
-	upstreams    []*url.URL
+	upstreams    []*Upstream
 	lastUpstream int
 	lock         sync.Mutex
 }
 
-// SelectTarget will load balance amongst available
+type Upstream struct {
+	url      *url.URL
+	failures int32
+}
+
+func (u *Upstream) Eligible() bool {
+	if u.failures >= 5 {
+		return false
+	}
+	return true
+}
+
+func (u *Upstream) CountFailure() {
+	// Add failure to upstream
+	atomic.AddInt32(&u.failures, 1)
+
+	// Subtract failure from upstream after
+	// a set period of time
+	go func(upstream *Upstream, d time.Duration) {
+		timer := time.NewTimer(d)
+		select {
+		case <-timer.C:
+		}
+		atomic.AddInt32(&upstream.failures, -1)
+	}(u, time.Second*5)
+}
+
+// SelectUpstream will load balance amongst available
 // targets using a round-robin algorithm
-func (t *Target) SelectTarget() *url.URL {
+func (t *Target) SelectUpstream() (*Upstream, error) {
 	count := len(t.upstreams)
 	if count == 1 {
-		return t.upstreams[0]
+		if !t.upstreams[0].Eligible() {
+			return nil, errors.New("target has no eligible upstream")
+		}
+		return t.upstreams[0], nil
 	}
 
 	t.lock.Lock()
@@ -29,7 +62,21 @@ func (t *Target) SelectTarget() *url.URL {
 		next = 0
 	}
 
+	attempts := 1
+	for !t.upstreams[next].Eligible() {
+		// We'll only attempt as many times as there are upstreams
+		if attempts >= count {
+			return nil, errors.New("target has no eligible upstream")
+		}
+
+		next := t.lastUpstream + 1
+		if next >= count {
+			next = 0
+		}
+		attempts++
+	}
+
 	t.lastUpstream = next
 
-	return t.upstreams[next]
+	return t.upstreams[next], nil
 }

--- a/reverseproxy/transport.go
+++ b/reverseproxy/transport.go
@@ -1,0 +1,35 @@
+package reverseproxy
+
+import (
+	"net/http"
+)
+
+type Transport struct {
+	base http.RoundTripper
+}
+
+func (t Transport) RoundTrip(r *http.Request) (*http.Response, error) {
+	res, err := t.base.RoundTrip(r)
+
+	// Error or (no error but status is a failure)
+	if err != nil || (err == nil && t.ResponseCountsAsFailure(res.StatusCode)) {
+		u, ok := GetVar(r.Context(), "upstream").(*Upstream)
+		if ok {
+			u.CountFailure()
+		}
+	}
+
+	return res, err
+}
+
+// ResponseCountsAsFailure decides if an HTTP status code
+// counts as a failure towards an upstream becoming ineligible
+func (t Transport) ResponseCountsAsFailure(status int) bool {
+	switch status {
+	case http.StatusBadGateway:
+	case http.StatusServiceUnavailable:
+	case http.StatusGatewayTimeout:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
**What:**

Passive health checks are health checks based on the response from a target upstream server.

> Versus active health checks, which would actively ping an upstream's endpoint to test a valid response

We hard-code setting an upstream as "ineligible" when it reaches 5 failures within 5 seconds.

This obviously should be configurable, we haven't designed a configuration system just yet.

**Future Configurable Things:**

1. Enable/disable passive health checks
2. Number of failures before marking unhealthy ("ineligible")
3. Duration for which failures stick around (e.g. `x` failures within `y` seconds)
4. What HTTP statuses count as a failure (if any)

**A failure is:**

1. An error from Transport's `RoundTrip()` method (e.g. unable to connect)
4. A `502`, `503`, or `504` HTTP response from an upstream

Those statuses:

```
	StatusBadGateway                    = 502 // RFC 9110, 15.6.3
	StatusServiceUnavailable            = 503 // RFC 9110, 15.6.4
	StatusGatewayTimeout                = 504 // RFC 9110, 15.6.5
```